### PR TITLE
Start with empty gamepath and set button accordingly if no Titanfall2 install found

### DIFF
--- a/src-vue/src/components/PlayButton.vue
+++ b/src-vue/src/components/PlayButton.vue
@@ -12,6 +12,8 @@ export default defineComponent({
             }
 
             switch(this.$store.state.northstar_state) {
+                case NorthstarState.GAME_NOT_FOUND:
+                    return "Titanfall2 not found";
                 case NorthstarState.INSTALL:
                     return "Install";
                 case NorthstarState.INSTALLING:

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -28,7 +28,7 @@ export const store = createStore({
         return {
             current_tab: Tabs.PLAY,
             developer_mode: false,
-            game_path: "this/is/the/game/path",
+            game_path: undefined,
             install_type: undefined,
 
             installed_northstar_version: "",

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -32,7 +32,7 @@ export const store = createStore({
             install_type: undefined,
 
             installed_northstar_version: "",
-            northstar_state: NorthstarState.INSTALL,
+            northstar_state: NorthstarState.GAME_NOT_FOUND,
             release_canal: ReleaseCanal.RELEASE,
 
             northstar_is_running: false,
@@ -189,5 +189,8 @@ async function _get_northstar_version_number(state: any) {
                 console.error(error);
                 alert(error);
             });
+    }
+    else {
+        state.northstar_state = NorthstarState.INSTALL;
     }
 }

--- a/src-vue/src/utils/NorthstarState.ts
+++ b/src-vue/src/utils/NorthstarState.ts
@@ -1,4 +1,5 @@
 export enum NorthstarState {
+    GAME_NOT_FOUND,
     INSTALL,
     INSTALLING,
     MUST_UPDATE,


### PR DESCRIPTION
Nulling out game path prevents installing NS to `this/is/the/game/path` if Titanfall2 folder was not found.

And additionally the button on the main view should be set accordingly if no Titanfall2 install was found.
Naturally clicking the button should allow you to select a location for Titanfall2 but that's a job for later ^^