### PR TITLE
Temporarily disable updater to avoid failing builds

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,7 @@
       "csp": null
     },
     "updater": {
-      "active": true,
+      "active": false,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEVBNjM3NzJGRDgxMTU4NUUKUldSZVdCSFlMM2RqNmdhK3pIZjhEYWg2WnZGSFJqdkhLSHNOSjNhaW5VQVFLaHV3YWFDTnFKWWQK",
       "endpoints": [
         "https://github.com/GeckoEidechse/FlightCore/releases/latest/download/latest-release.json"


### PR DESCRIPTION
Should be re-enabled before merging into main on upstream and in the longterm disabled in CI if private key is missing.