### PR TITLE
Show notification if FlightCore is outdated

### DIFF
--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -149,8 +149,21 @@ async function _initializeApp(state: any) {
 }
 
 async function _checkForFlightCoreUpdates(state: FlightCoreStore) {
-    // Check if up-to-date
+    // Check if FlightCore up-to-date
     let flightcore_is_outdated = await invoke("check_is_flightcore_outdated_caller") as boolean;
+
+    // Get FlightCore version number
+    let flightcore_version_number = await invoke("get_version_number") as string;
+
+    if (flightcore_is_outdated) {
+        ElNotification({
+            title: 'FlightCore outdated!',
+            message: `Please update FlightCore. Running outdated version ${flightcore_version_number}`,
+            type: 'warning',
+            position: 'bottom-right',
+            duration: 0 // Duration `0` means the notification will not auto-vanish
+        });
+    }
 }
 
 /**

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -149,50 +149,8 @@ async function _initializeApp(state: any) {
 }
 
 async function _checkForFlightCoreUpdates(state: FlightCoreStore) {
-    // Get version number
-    let version_number_string = await invoke("get_version_number") as string;
     // Check if up-to-date
     let flightcore_is_outdated = await invoke("check_is_flightcore_outdated_caller") as boolean;
-    // Get host OS
-    let host_os_string = await invoke("get_host_os_caller") as string;
-    
-    // Get install location
-    await invoke("find_game_install_location_caller", { gamePath: state.game_path })
-        .then((game_install) => {
-            // Found some gamepath
-            let game_install_obj = game_install as GameInstall;
-
-            // Change installation state based on whether game install was found
-            state.northstar_state = NorthstarState.INSTALL;
-            state.game_path = game_install_obj.game_path;
-            state.install_type = game_install_obj.install_type as InstallType;
-
-            // Check installed Northstar version if found
-            _get_northstar_version_number(state);
-        })
-        .catch((error) => {
-            // Gamepath not found or other error
-            ElNotification({
-                title: "Couldn't find game path",
-                message: error,
-                type: 'warning',
-                position: 'bottom-right'
-            });
-            state.northstar_state = NorthstarState.GAME_NOT_FOUND;
-        });
-
-    // --- This should be moved and is only placed here temporarily -----
-    let game_install = {
-        game_path: state.game_path,
-        install_type: state.install_type.toString()
-    } as GameInstall;
-    await invoke("get_log_list_caller", { gameInstall: game_install })
-        .then((message) => {
-            console.log(message);
-        })
-        .catch((error) => {
-            console.error(error);
-        });
 }
 
 /**


### PR DESCRIPTION
The notification is set to not auto-expiry to avoid the case of the user missing it due to opening the application in the background. 

For the future it would be nice to also have a watermark in the background that shows if FlightCore is outdated to be able to immediately tell in any support ticket whether the issue the user is having is simply caused by an outdated version of FlightCore but this is good enough for the UI rewrite PR right now.

Also strips unused copied code that was previously in the same area.

![image](https://user-images.githubusercontent.com/40122905/193838025-ddc0ba85-d033-42f6-b41d-31dc9627a6b7.png)

